### PR TITLE
Updated package name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "automate",
+  "name": "cron-automate",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "automate",
+      "name": "cron-automate",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "automate",
+  "name": "cron-automate",
   "version": "0.0.1",
   "description": "A NPM Package to Automate CronJob.",
   "keywords": [
@@ -7,13 +7,13 @@
     "cron-job",
     "npm"
   ],
-  "homepage": "https://github.com/anmol420/Automate#readme",
+  "homepage": "https://github.com/anmol420/cron-automate#readme",
   "bugs": {
-    "url": "https://github.com/anmol420/Automate/issues"
+    "url": "https://github.com/anmol420/cron-automate/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/anmol420/Automate.git"
+    "url": "git+https://github.com/anmol420/cron-automate.git"
   },
   "license": "MIT",
   "author": "anmol420",

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -1,14 +1,14 @@
 {
-  "name": "example",
+  "name": "test",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "example",
+      "name": "test",
       "version": "1.0.0",
       "dependencies": {
-        "automate": "file:../packs/automate-0.0.1.tgz"
+        "cron-automate": "file:../packs/cron-automate-0.0.1.tgz"
       }
     },
     "node_modules/@ioredis/commands": {
@@ -17,15 +17,6 @@
       "integrity": "sha512-M/T6Zewn7sDaBQEqIZ8Rb+i9y8qfGmq+5SDFSf9sA2lUZTmdDLVdOiQaeDp+Q4wElZ9HG1GAX5KhDaidp6LQsQ==",
       "license": "MIT"
     },
-    "node_modules/automate": {
-      "version": "0.0.1",
-      "resolved": "file:../packs/automate-0.0.1.tgz",
-      "integrity": "sha512-8C6WBtD4SO0Hg22sewyfqMlmuZqwRqoFixa9wK4YRTGVl8SrsG4c2HdnCaJP17OxYq/q9PuMxUAAkJiu1MA+ZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ioredis": "^5.7.0"
-      }
-    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
@@ -33,6 +24,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cron-automate": {
+      "version": "0.0.1",
+      "resolved": "file:../packs/cron-automate-0.0.1.tgz",
+      "integrity": "sha512-Ze9G9AkSxMySwtzpn3npA4GiI+pMidNUCZRQ2ctFLxUCkw8Vv4g/LzS/gF1naYStL+K94EVvunh5QFyjdrX3Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "ioredis": "^5.7.0"
       }
     },
     "node_modules/debug": {

--- a/test/package.json
+++ b/test/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "example",
+  "name": "test",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
@@ -10,6 +10,6 @@
   "author": "anmol420",
   "type": "module",
   "dependencies": {
-    "automate": "file:../packs/automate-0.0.1.tgz"
+    "cron-automate": "file:../packs/cron-automate-0.0.1.tgz"
   }
 }

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -1,4 +1,4 @@
-import { getRedis, disconnectRedis } from "automate";
+import { getRedis, disconnectRedis } from "cron-automate";
 
 import connection from "./redisCon/redisConnect.js";
 

--- a/test/src/redisCon/redisConnect.js
+++ b/test/src/redisCon/redisConnect.js
@@ -1,4 +1,4 @@
-import { connectRedis } from "automate";
+import { connectRedis } from "cron-automate";
 
 // redis running on docker
 const connection = () => connectRedis("redis://localhost:6379");


### PR DESCRIPTION
This pull request updates the package name from `automate` to `cron-automate` throughout the codebase and test files to reflect a rebranding or renaming of the package. All related references, dependencies, and imports have been updated accordingly.

**Package and Dependency Updates:**

* Renamed the main package in `package.json` from `automate` to `cron-automate`, and updated the `homepage`, `bugs`, and `repository` URLs to match the new package name.
* Updated the test package (`test/package.json` and `test/package-lock.json`) to use `cron-automate` instead of `automate` as a dependency, and renamed the test package itself from `example` to `test`. [[1]](diffhunk://#diff-b9188cc104c28fc06ff913ef07a9fa1a038b3f4de944a86c32f85fe3df17efafL2-R2) [[2]](diffhunk://#diff-b9188cc104c28fc06ff913ef07a9fa1a038b3f4de944a86c32f85fe3df17efafL13-R13) [[3]](diffhunk://#diff-304309dddab548e91bface540850d1491e0ccb13255c02d91d456632a3d71f7aL2-R11) [[4]](diffhunk://#diff-304309dddab548e91bface540850d1491e0ccb13255c02d91d456632a3d71f7aL20-L28) [[5]](diffhunk://#diff-304309dddab548e91bface540850d1491e0ccb13255c02d91d456632a3d71f7aR29-R37)

**Code Import Updates:**

* Changed all import statements in test source files to import from `cron-automate` instead of `automate` (`test/src/index.js`, `test/src/redisCon/redisConnect.js`). [[1]](diffhunk://#diff-491c4f7417c1a2d01e00d1552e9f3420e875a3edf3c8089b6fd820f19e5e2c89L1-R1) [[2]](diffhunk://#diff-33b5879babb9688ec64d3111c2d0d45d164bc89c57b03dd1480cdc2295169070L1-R1)